### PR TITLE
Add AI Ops profile page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
-# Profile
+# AI Ops Profile
+
+This repository contains a simple static page for showcasing a professional AI Ops engineer's GitHub profile. The page lives in `index.html` and can be served using GitHub Pages or any other static hosting provider.
+
+## Usage
+1. Clone this repository.
+2. Edit `index.html` to include your own details.
+3. Enable GitHub Pages or host the file elsewhere to publish your profile.

--- a/index.html
+++ b/index.html
@@ -1,182 +1,80 @@
-<!-- 
-Hey Rajinikanth! 
-To make this truly "3D" and dynamic, we'll use a few tricks:
-1.  A cool header image/GIF.
-2.  GitHub Stats cards with themes that have a bit of depth.
-3.  GitHub Skyline for a literal 3D view of your contributions.
-4.  A "snake" game animation of your contribution graph.
-5.  Icons for your skills for visual appeal.
--->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>AI Ops Engineer Profile</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      line-height: 1.6;
+      max-width: 900px;
+      margin: 0 auto;
+      padding: 1rem;
+    }
+    header, section {
+      text-align: center;
+    }
+    hr {
+      margin: 2rem 0;
+    }
+    img.stats {
+      max-width: 100%;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <img src="https://media.giphy.com/media/QaMcY2W4ReTe0oK2Y1/giphy.gif" alt="Coding" width="600">
+    <h1>Hi there, I'm Alex Ops</h1>
+    <h3>AI Ops Engineer | Cloud Automation | MLOps Practitioner</h3>
+    <p>
+      <a href="https://www.linkedin.com/in/YOUR_LINKEDIN/">LinkedIn</a> |
+      <a href="mailto:YOUR_EMAIL@example.com">Email</a>
+    </p>
+  </header>
 
-<p align="center">
-  <a href="https://github.com/rajinikanthvadla-ai">
-    <!-- You can find cool header images/GIFs on sites like Giphy or create your own -->
-    <!-- Option 1: A dynamic tech GIF -->
-    <img src="https://media.giphy.com/media/QaMcY2W4ReTe0oK2Y1/giphy.gif" alt="Coding GIF" width="600"/>
-    <!-- Option 2: A more static, but professional banner (create one on Canva or similar) -->
-    <!-- <img src="YOUR_CUSTOM_BANNER_URL_HERE" alt="Rajinikanth Vadla - AI Specialist" width="800"/> -->
-  </a>
-</p>
+  <hr>
 
-<h1 align="center">Hi there, I'm Rajinikanth Vadla <img src="https://media.giphy.com/media/hvRJCLFzcasrR4ia7z/giphy.gif" width="35"></h1>
-<h3 align="center">AI & Machine Learning Engineer | MLOps Practitioner | Building Intelligent Solutions</h3>
+  <section>
+    <h2>About Me</h2>
+    <p>
+      I'm a professional dedicated to building reliable and scalable AI systems. My interests include automation, observability, and applying machine learning to improve operations.
+    </p>
+  </section>
 
-<p align="center">
-  <a href="https://www.linkedin.com/in/YOUR_LINKEDIN_PROFILE_ID_HERE/" target="_blank"><img src="https://img.shields.io/badge/LinkedIn-0077B5?style=for-the-badge&logo=linkedin&logoColor=white" alt="LinkedIn"/></a>
-  <a href="mailto:YOUR_EMAIL_HERE@example.com"><img src="https://img.shields.io/badge/Email-D14836?style=for-the-badge&logo=gmail&logoColor=white" alt="Email"/></a>
-  <!-- Add other social links if you have them -->
-</p>
+  <section>
+    <h2>Skills</h2>
+    <p>
+      Python • Docker • Kubernetes • AWS • Terraform • Prometheus • Grafana
+    </p>
+  </section>
 
----
+  <hr>
 
-🚀 I'm an AI/ML enthusiast passionate about leveraging data to build impactful and intelligent applications. My core interests lie in **Deep Learning, Computer Vision, Natural Language Processing, Generative AI, and MLOps**. I enjoy transforming complex problems into scalable and efficient solutions.
+  <section>
+    <h2>GitHub Stats</h2>
+    <p>
+      <img class="stats" src="https://github-readme-stats.vercel.app/api?username=YOUR_GITHUB_USERNAME&show_icons=true&theme=radical" alt="GitHub Stats">
+      <br>
+      <img class="stats" src="https://github-readme-stats.vercel.app/api/top-langs/?username=YOUR_GITHUB_USERNAME&layout=compact&theme=radical" alt="Top Languages">
+    </p>
+  </section>
 
-🌱 I’m currently diving deeper into:
-*   Advanced Large Language Models (LLMs) and their applications.
-*   End-to-end MLOps pipelines for robust model deployment and monitoring.
-*   Reinforcement Learning and its potential in various domains.
+  <hr>
 
-👯 I’m looking to collaborate on open-source AI projects, especially those related to social good or cutting-edge research.
+  <section>
+    <h2>Highlighted Projects</h2>
+    <ul>
+      <li><a href="#">Project 1</a> - Describe your AI Ops project here.</li>
+      <li><a href="#">Project 2</a> - Another cool project description.</li>
+    </ul>
+  </section>
 
-💬 Ask me about: Python, TensorFlow, PyTorch, Scikit-learn, Computer Vision (YOLO, OpenCV), NLP (Langchain, Transformers), Streamlit, AWS, Docker, MLOps.
+  <hr>
 
----
-
-<h2 align="center">🛠️ My Tech Stack 🛠️</h2>
-<p align="center">
-  <!-- Languages -->
-  <img src="https://img.shields.io/badge/Python-3776AB?style=for-the-badge&logo=python&logoColor=white" alt="Python"/>
-  <img src="https://img.shields.io/badge/SQL-00758F?style=for-the-badge&logo=A8A8A8&logoColor=white" alt="SQL"/>
-  <!-- Frameworks & Libraries -->
-  <img src="https://img.shields.io/badge/TensorFlow-FF6F00?style=for-the-badge&logo=tensorflow&logoColor=white" alt="TensorFlow"/>
-  <img src="https://img.shields.io/badge/PyTorch-EE4C2C?style=for-the-badge&logo=pytorch&logoColor=white" alt="PyTorch"/>
-  <img src="https://img.shields.io/badge/scikit--learn-F7931E?style=for-the-badge&logo=scikit-learn&logoColor=white" alt="Scikit-learn"/>
-  <img src="https://img.shields.io/badge/Pandas-150458?style=for-the-badge&logo=pandas&logoColor=white" alt="Pandas"/>
-  <img src="https://img.shields.io/badge/NumPy-013243?style=for-the-badge&logo=numpy&logoColor=white" alt="NumPy"/>
-  <img src="https://img.shields.io/badge/OpenCV-5C3EE8?style=for-the-badge&logo=opencv&logoColor=white" alt="OpenCV"/>
-  <img src="https://img.shields.io/badge/Streamlit-FF4B4B?style=for-the-badge&logo=streamlit&logoColor=white" alt="Streamlit"/>
-  <img src="https://img.shields.io/badge/LangChain-02923E?style=for-the-badge&logo=LangChain&logoColor=white" alt="LangChain"/> <!-- You might need to find a good LangChain logo or use a generic one -->
-  <!-- Cloud & MLOps -->
-  <img src="https://img.shields.io/badge/Amazon_AWS-232F3E?style=for-the-badge&logo=amazon-aws&logoColor=white" alt="AWS"/>
-  <img src="https://img.shields.io/badge/Docker-2496ED?style=for-the-badge&logo=docker&logoColor=white" alt="Docker"/>
-  <img src="https://img.shields.io/badge/Git-F05032?style=for-the-badge&logo=git&logoColor=white" alt="Git"/>
-  <!-- Add more as you see fit! -->
-</p>
-
----
-
-<h2 align="center">📊 My GitHub Stats 📊</h2>
-
-<p align="center">
-  <img src="https://github-readme-stats.vercel.app/api?username=rajinikanthvadla-ai&show_icons=true&theme=radical&rank_icon=github&count_private=true&hide_border=true" alt="Rajinikanth's GitHub Stats" />
-  <br/>
-  <img src="https://github-readme-stats.vercel.app/api/top-langs/?username=rajinikanthvadla-ai&layout=compact&theme=radical&hide_border=true&langs_count=8" alt="Top Languages" />
-</p>
-<p align="center">
-  <img src="https://github-readme-streak-stats.herokuapp.com/?user=rajinikanthvadla-ai&theme=radical&hide_border=true" alt="GitHub Streak Stats"/>
-</p>
-
----
-
-<h2 align="center"> ✨ My GitHub Skyline ✨ (3D Contribution View)</h2>
-<p align="center">
-  Give your GitHub Skyline a spin! It's a 3D visualization of your contribution graph.
-  <br/>
-  <a href="https://skyline.github.com/rajinikanthvadla-ai/2023"> <!-- Change 2023 to current year or any year you want to showcase -->
-    <img src="https://skyline.github.com/rajinikanthvadla-ai/2023.png" alt="GitHub Skyline 2023" width="500">
-  </a>
-  <br/>
-  You can generate this for any year by visiting: <code>https://skyline.github.com/YOUR_USERNAME/YEAR</code>
-</p>
-
----
-
-<h2 align="center"> 🐍 My Contribution Graph (Snake Game Style!) </h2>
-<p align="center">
-  <img src="https://raw.githubusercontent.com/rajinikanthvadla-ai/rajinikanthvadla-ai/output/github-contribution-grid-snake.svg" alt="GitHub Contribution Snake Animation">
-</p>
-<!-- 
-To make the snake game work, you need to:
-1. Create a GitHub Actions workflow in this repository.
-   File: `.github/workflows/main.yml`
-   Content for main.yml:
-   ------------------------------------
-   name: Generate Snake Animation
-
-   on:
-     schedule:
-       - cron: "0 0 * * *" # Runs daily at midnight
-     workflow_dispatch: # Allows manual triggering
-
-   jobs:
-     build:
-       runs-on: ubuntu-latest
-       steps:
-         - name: Checkout
-           uses: actions/checkout@v3
-
-         - name: Generate Snake Animation
-           uses: Platane/snk@v3
-           with:
-             github_user_name: ${{ github.repository_owner }}
-             # list of files to generate.
-             # one file per line. Each new line uses a different color!
-             # Self path needs to be destination path from repository root
-             outputs: |
-               dist/github-contribution-grid-snake.svg
-               dist/github-contribution-grid-snake-dark.svg?palette=github-dark
-           env:
-             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-   ------------------------------------
-2. Commit and push this workflow file.
-3. Manually run the "Generate Snake Animation" workflow once from the Actions tab of your `rajinikanthvadla-ai` repository.
-4. Update the image path in this README if you change the `outputs` path in the workflow.
-   The default path used above `raw.githubusercontent.com/rajinikanthvadla-ai/rajinikanthvadla-ai/output/github-contribution-grid-snake.svg`
-   should be updated to point to the `dist` folder that the action creates like:
-   `raw.githubusercontent.com/rajinikanthvadla-ai/rajinikanthvadla-ai/main/dist/github-contribution-grid-snake.svg`
-   Ensure the branch name (`main` or `master`) is correct.
--->
-
----
-
-<h2 align="center">🌟 Featured Projects 🌟</h2>
-<p align="center">
-  <i>A few highlights from my repositories:</i>
-</p>
-<table align="center">
-  <tr>
-    <td width="50%" valign="top">
-      <h3><a href="https://github.com/rajinikanthvadla-ai/Customer_Churn_Prediction_WEB_APP_Streamlit">📊 Customer Churn Prediction Web App</a></h3>
-      <p>A Streamlit web application for predicting customer churn using machine learning.</p>
-      <p><code>Python</code> <code>Streamlit</code> <code>Scikit-learn</code> <code>Pandas</code></p>
-    </td>
-    <td width="50%" valign="top">
-      <h3><a href="https://github.com/rajinikanthvadla-ai/Automatic_Number_Plate_Recognition_using_YOLOv8_EasyOCR">🚗 Automatic Number Plate Recognition</a></h3>
-      <p>ANPR system leveraging YOLOv8 for object detection and EasyOCR for text extraction.</p>
-      <p><code>Python</code> <code>YOLOv8</code> <code>EasyOCR</code> <code>OpenCV</code></p>
-    </td>
-  </tr>
-  <tr>
-    <td width="50%" valign="top">
-      <h3><a href="https://github.com/rajinikanthvadla-ai/Face_Recognition_based_Attendance_System">👤 Face Recognition Attendance System</a></h3>
-      <p>An attendance system built using facial recognition technology.</p>
-      <p><code>Python</code> <code>OpenCV</code> <code>face_recognition</code></p>
-    </td>
-    <td width="50%" valign="top">
-      <h3><a href="https://github.com/rajinikanthvadla-ai/Langchain_applications_">💬 LangChain Applications</a></h3>
-      <p>Exploring various applications built using the LangChain framework for LLMs.</p>
-      <p><code>Python</code> <code>LangChain</code> <code>LLMs</code></p>
-    </td>
-  </tr>
-  <!-- Add more projects if you like -->
-</table>
-
----
-
-<p align="center">
-  <img src="https://komarev.com/ghpvc/?username=rajinikanthvadla-ai&label=Profile%20Views&color=0e75b6&style=flat-square" alt="Profile Views"/>
-</p>
-
-<p align="center">
-  Thanks for visiting my profile! Let's connect and build something amazing.
-</p>
+  <footer>
+    <p>Thanks for visiting my profile!</p>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create static GitHub profile page for a professional AI Ops engineer
- update repository README with usage instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68414de04aa0832ab150fe1c6ea453ae